### PR TITLE
implement default size configuration parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,14 @@ Then use the `screenshot` directive in your Sphinx source file.
 .. screenshot:: http://www.example.com
 ```
 
-You can also specify the screen size for the screenshot with `width` and `height` parameters.
+You can define the default size of your screenshots in `conf.py`:
+
+```python
+screenshot_default_width = 1920
+screenshot_default_height = 1200
+```
+
+You can also specify the screen size for a particular screenshot with `width` and `height` parameters.
 
 ```rst
 .. screenshot:: http://www.example.com

--- a/sphinxcontrib/screenshot.py
+++ b/sphinxcontrib/screenshot.py
@@ -167,8 +167,9 @@ class ScreenshotDirective(SphinxDirective):
 
     # Parse parameters
     url = self.evaluate_substitutions(self.arguments[0])
-    height = self.options.get('height', 960)
-    width = self.options.get('width', 1280)
+    height = self.options.get('height',
+                              self.env.config.screenshot_default_height)
+    width = self.options.get('width', self.env.config.screenshot_default_width)
     color_scheme = self.options.get('color-scheme', 'null')
     caption_text = self.options.get('caption', '')
     figclass = self.options.get('figclass', '')
@@ -248,6 +249,16 @@ def teardown_apps(app: Sphinx, exception: typing.Optional[Exception]):
 def setup(app: Sphinx) -> Meta:
   app.add_directive('screenshot', ScreenshotDirective)
   app.add_config_value('screenshot_init_script', '', 'env')
+  app.add_config_value(
+      'screenshot_default_width',
+      1280,
+      'env',
+      description="The default width for screenshots")
+  app.add_config_value(
+      'screenshot_default_height',
+      960,
+      'env',
+      description="The default height for screenshots")
   app.add_config_value(
       'screenshot_apps', {},
       'env',

--- a/tests/roots/test-default-size/conf.py
+++ b/tests/roots/test-default-size/conf.py
@@ -1,0 +1,16 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+extensions = ['sphinxcontrib.screenshot']
+screenshot_default_width = 1920
+screenshot_default_height = 1200

--- a/tests/roots/test-default-size/index.rst
+++ b/tests/roots/test-default-size/index.rst
@@ -1,0 +1,1 @@
+.. screenshot:: https://www.example.com

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from io import StringIO
+
 import pytest
 from bs4 import BeautifulSoup
 from PIL import Image
@@ -55,3 +57,20 @@ def test_default(app: SphinxTestApp) -> None:
   assert imgsrc_before_interaction != imgsrc_after_interaction
   assert list(Image.open(imgsrc_before_interaction).getdata()) != list(
       Image.open(imgsrc_after_interaction).getdata())
+
+
+@pytest.mark.sphinx('html', testroot="default-size")
+def test_default_size(app: SphinxTestApp, status: StringIO, warning: StringIO,
+                      image_regression) -> None:
+  """Test the 'screenshot_default_width' and
+  'screenshot_default_height' configuration parameters."""
+  app.build()
+  out_html = app.outdir / "index.html"
+
+  soup = BeautifulSoup(out_html.read_text(), "html.parser")
+  imgs = soup.find_all('img')
+
+  img_obj = Image.open(app.outdir / imgs[0]['src'])
+  width, height = img_obj.size
+  assert width == 1920
+  assert height == 1200


### PR DESCRIPTION
This PR adds `screenshot_default_width` and `screenshot_default_height` configuration parameters to avoid redefining `:width:` and `:height:` for all screenshots.