### PR TITLE
Implement :status-code: parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A Sphinx extension to embed website screenshots.
   :viewport-width: 1280
   :viewport-height: 960
   :color-scheme: dark
+  :status-code: 200,302
 ```
 
 Read more in the [documentation](https://sphinxcontrib-screenshot.readthedocs.io).

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -188,6 +188,26 @@ You can set the timezone for the browser context:
       :timezone: America/New_York
 
 
+.. _status-code:
+
+``:status-code:``
+=================
+
+You can specify the expected HTTP status codes. A warning is emitted if the page returns a different code.
+
+.. code-block:: rst
+
+    .. screenshot:: http://www.example.com
+      :status-code: 200,201,302
+
+Default: ``200,302``
+
+The warning can be suppressed in ``conf.py``:
+
+.. code-block:: python
+
+    suppress_warnings = ['screenshot.status_code']
+
 .. _viewport_width:
 .. _viewport_height:
 

--- a/tests/roots/test-status-code-warning/conf.py
+++ b/tests/roots/test-status-code-warning/conf.py
@@ -1,0 +1,21 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).parent.resolve()))
+
+extensions = ['sphinxcontrib.screenshot']
+screenshot_apps = {"app404": "example_404_app:create_app"}

--- a/tests/roots/test-status-code-warning/example_404_app.py
+++ b/tests/roots/test-status-code-warning/example_404_app.py
@@ -1,0 +1,34 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def create_app(sphinx_app):
+  """Create a WSGI app that returns 404 Not Found."""
+
+  def app_404(environ, start_response):
+    headers = [('Content-type', 'text/html; charset=utf-8')]
+    start_response('404 Not Found', headers)
+    style = (b"font-family: arial; "
+             b"font-size: 30px; "
+             b"padding: 0; "
+             b"margin: 0; "
+             b"font-smooth: never; "
+             b"line-height: 1.15;")
+
+    return [
+        b"<html>" + b'<body style="' + style + b'">' +
+        b"Status: 404 Not Found" + b"</body>" + b"</html>"
+    ]
+
+  return app_404

--- a/tests/roots/test-status-code-warning/index.rst
+++ b/tests/roots/test-status-code-warning/index.rst
@@ -1,0 +1,3 @@
+.. screenshot:: |app404|
+  :width: 400
+  :height: 300

--- a/tests/test_status_code.py
+++ b/tests/test_status_code.py
@@ -1,0 +1,34 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from io import StringIO
+
+import pytest
+from sphinx.testing.util import SphinxTestApp
+
+
+@pytest.mark.sphinx('html', testroot="status-code-warning")
+def test_status_code_warning_on_404(app: SphinxTestApp, status: StringIO,
+                                    warning: StringIO) -> None:
+  """Test that 404 status code generates a warning with default settings.
+
+  This test uses a WSGI app that returns 404, which should trigger a warning
+  since the default expected status codes are 200,302.
+  """
+  app.build()
+  warning_text = warning.getvalue()
+
+  assert "404" in warning_text
+  assert "200,302" in warning_text
+  assert "WARNING" in warning_text


### PR DESCRIPTION
Sometimes you move a view in your application but forget to update the screenshot URL.
Now by default status codes that are not 200 or 302 raise a warning. This is customizable with `:status-code:`