### PR TITLE
Automatic dark mode

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include README.md
+include LICENSE
+recursive-include sphinxcontrib/screenshot/static *.css

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,11 +61,13 @@ doc = [
 ]
 
 [tool.setuptools]
-packages = ["sphinxcontrib"]
 include-package-data = true
 
+[tool.setuptools.packages.find]
+include = ["sphinxcontrib*"]
+
 [tool.setuptools.package-data]
-"sphinxcontrib" = ["*"]
+"sphinxcontrib.screenshot" = ["static/*"]
 
 [tool.yapf]
 based_on_style = "yapf"

--- a/sphinxcontrib/screenshot/static/screenshot-theme.css
+++ b/sphinxcontrib/screenshot/static/screenshot-theme.css
@@ -1,0 +1,12 @@
+.only-dark {
+    display: none;
+}
+
+@media (prefers-color-scheme: dark) {
+    .only-light {
+        display: none;
+    }
+    .only-dark {
+        display: revert;
+    }
+}

--- a/tests/roots/test-auto-dark/conf.py
+++ b/tests/roots/test-auto-dark/conf.py
@@ -1,0 +1,20 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).parent.resolve()))
+
+extensions = ['sphinxcontrib.screenshot']
+screenshot_apps = {"example": "example_auto_dark_app:create_app"}

--- a/tests/roots/test-auto-dark/example_auto_dark_app.py
+++ b/tests/roots/test-auto-dark/example_auto_dark_app.py
@@ -1,0 +1,27 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import pathlib
+
+
+def create_app(sphinx_app):
+
+  def hello_world_app(environ, start_response):
+    headers = [('Content-type', 'text/html; charset=utf-8')]
+    start_response('200 OK', headers)
+
+    path = pathlib.Path(__file__).parent.resolve() / "index.html"
+    with open(path, "rb") as fd:
+      return [fd.read()]
+
+  return hello_world_app

--- a/tests/roots/test-auto-dark/index.html
+++ b/tests/roots/test-auto-dark/index.html
@@ -1,0 +1,29 @@
+<html>
+    <head>
+        <style>
+        :root {
+            --background-color: #FFFFFF;
+            --text-color: #000000;
+        }
+
+        @media (prefers-color-scheme: dark) {
+            :root {
+                --background-color: #000000;
+                --text-color: #FFFFFF;
+            }
+        }
+
+        body {
+                background: var(--background-color);
+                color: var(--text-color);
+                font-family: arial;
+                font-size: 10px;
+                margin: 0;
+                padding: 0
+            }
+        </style>
+    </head>
+    <body>
+        Hello, auto dark mode!
+    </body>
+</html>

--- a/tests/roots/test-auto-dark/index.rst
+++ b/tests/roots/test-auto-dark/index.rst
@@ -1,0 +1,4 @@
+.. screenshot:: |example|
+   :viewport-width: 800
+   :viewport-height: 600
+   :color-scheme: auto

--- a/tests/test_color_scheme.py
+++ b/tests/test_color_scheme.py
@@ -46,3 +46,60 @@ def test_default_color_scheme_config_parameter(app: SphinxTestApp,
   img_path = app.outdir / imgs[0]['src']
   with open(img_path, "rb") as fd:
     image_regression.check(fd.read())
+
+
+@pytest.mark.sphinx('html', testroot="auto-dark")
+def test_auto_dark_generates_two_images(app: SphinxTestApp, status: StringIO,
+                                        warning: StringIO) -> None:
+  """Test that :color-scheme: auto generates two screenshots.
+
+  The screenshots should have appropriate CSS classes.
+  """
+  app.build()
+  out_html = app.outdir / "index.html"
+
+  soup = BeautifulSoup(out_html.read_text(), "html.parser")
+  imgs = soup.find_all('img')
+
+  assert len(imgs) == 2, "Should generate exactly two images (light and dark)"
+
+  light_img = imgs[0]
+  dark_img = imgs[1]
+
+  assert 'only-light' in light_img.get(
+      'class', []), "First image should have 'only-light' class"
+  assert 'only-dark' in dark_img.get(
+      'class', []), "Second image should have 'only-dark' class"
+
+  screenshots_dir = app.outdir / "_static" / "screenshots"
+  assert screenshots_dir.exists(), "Screenshots directory should exist"
+
+  light_img_path = app.outdir / light_img['src']
+  dark_img_path = app.outdir / dark_img['src']
+
+  assert light_img_path.exists(), "Light mode screenshot should exist"
+  assert dark_img_path.exists(), "Dark mode screenshot should exist"
+
+  assert light_img_path != dark_img_path, (
+      "Light and dark screenshots should be different files")
+
+
+@pytest.mark.sphinx('html', testroot="auto-dark")
+def test_auto_dark_includes_css(app: SphinxTestApp, status: StringIO,
+                                warning: StringIO) -> None:
+  """Test that the CSS file is included when using :color-scheme: auto."""
+  app.build()
+  out_html = app.outdir / "index.html"
+
+  soup = BeautifulSoup(out_html.read_text(), "html.parser")
+  css_links = soup.find_all('link', rel='stylesheet')
+
+  css_hrefs = [link.get('href', '') for link in css_links]
+  assert any('screenshot-theme.css' in href for href in css_hrefs), (
+      "screenshot-theme.css should be included in the HTML")
+
+  css_file_path = (
+      app.outdir / "_static" / "sphinxcontrib-screenshot" /
+      "screenshot-theme.css")
+  assert css_file_path.exists(), (
+      "CSS file should be copied to output directory")


### PR DESCRIPTION
This PR adds `:color-scheme: auto`, which takes two screenshots, one in light mode and one in dark mode. The two images are then embedded in the generated pages, but only one is displayed depending on `prefers-color-scheme` with some lines of custom CSS.

I have tried to do something with <[picture](https://developer.mozilla.org/en/docs/Web/HTML/Reference/Elements/picture)> and <[source](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/source)> but these elements seems to not be supported by Sphinx yet. This is too bad because that would remove the need for custom CSS. If you have a better idea to use these tags, I am all ears :)

The CSS automatically detects the system dark mode preference, but if themes like furo or shibuya use their own switch button instead of relying on the system preferenence, they need to add custom CSS to show/hide the right screenshots.
