### PR TITLE
bump to v1.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sphinxcontrib-screenshot"
-version = "0.3.0"
+version = "1.0.0"
 description = "A Sphinx extension to embed webpage screenshots."
 readme = "README.md"
 license = { text = "Apache-2.0" }
@@ -13,7 +13,7 @@ authors = [
 ]
 urls = { repository = "https://github.com/tushuhei/sphinxcontrib-screenshot/" }
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 5 - Production/Stable",
     "Operating System :: OS Independent",
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
Bumping the version of sphinxcontrib-screenshot to 1.0.0 and updating its development status to Production/Stable. Verified that all tests pass.

---
*PR created automatically by Jules for task [6117198702715305848](https://jules.google.com/task/6117198702715305848) started by @tushuhei*