### PR TITLE
Implement `:locator:` to match a given element in the page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ build
 dist
 .coverage
 .tox
+uv.lock

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -150,6 +150,34 @@ You can describe the interaction that you want to have with the webpage before t
         document.querySelector('button').click();
 
 
+.. _locator:
+
+``:locator:``
+=============
+
+You can crop the screenshot to a single element on the page using a
+`Playwright selector <https://playwright.dev/python/docs/locators>`__.
+The image is bounded by the element's bounding box rather than the
+viewport.
+
+.. code-block:: rst
+
+    .. screenshot:: http://www.example.com
+      :locator: #content
+
+The page is still rendered at the full :ref:`viewport <viewport_width>`,
+so layout (responsive design, scrollbars) reflects the configured
+viewport size; only the captured area is reduced to the matched element.
+
+The selector must match exactly one element (Playwright strict mode).
+A multi-match selector raises an error; refine the selector. If no
+element is matched within :ref:`timeout <timeout>`, the build fails.
+
+When combined with :ref:`full-page <full-page>`, ``:locator:`` wins
+(the bounding box is honored). When combined with :ref:`pdf <pdf>`,
+the PNG is cropped but the PDF stays page-level — Playwright's PDF
+API has no per-element variant.
+
 .. _locale:
 
 ``:locale:``
@@ -178,7 +206,7 @@ It also generates a PDF file when :code:`pdf` option is given, which might be us
 .. _timezone:
 
 ``:timezone:``
-=============
+==============
 
 You can set the timezone for the browser context:
 
@@ -341,7 +369,7 @@ This is the default value to use when :ref:`:locale: <locale>` is not set. Defau
 
 
 ``screenshot_default_timezone``
-==============================
+===============================
 
 This is the default value to use when :ref:`:timezone: <timezone>` is not set. Defaults to `None`.
 

--- a/sphinxcontrib/screenshot/__init__.py
+++ b/sphinxcontrib/screenshot/__init__.py
@@ -110,6 +110,14 @@ class ScreenshotDirective(SphinxDirective, Figure):
     :color-scheme: auto
   ```
 
+  You can crop the screenshot to a single element on the page using a
+  Playwright selector. The image is bounded by the element's bounding box.
+
+  ```rst
+  .. screenshot:: http://www.example.com
+    :locator: #content
+  ```
+
   You can take a screenshot of a local file using a root-relative path.
 
   ```rst
@@ -146,6 +154,7 @@ class ScreenshotDirective(SphinxDirective, Figure):
       'device-scale-factor': directives.positive_int,
       'status-code': str,
       'timeout': directives.positive_int,
+      'locator': str,
   }
   pool = ThreadPoolExecutor()
 
@@ -167,7 +176,8 @@ class ScreenshotDirective(SphinxDirective, Figure):
                       timezone: typing.Optional[str],
                       expected_status_codes: typing.Optional[str] = None,
                       location: typing.Optional[str] = None,
-                      timeout: int = 10000):
+                      timeout: int = 10000,
+                      locator: typing.Optional[str] = None):
     """Takes a screenshot with Playwright's Chromium browser.
 
     Args:
@@ -183,7 +193,8 @@ class ScreenshotDirective(SphinxDirective, Figure):
         after the page was loaded.
       generate_pdf (bool): Generate a PDF file along with the screenshot.
       color_scheme (str): The preferred color scheme. Can be 'light' or 'dark'.
-      full_page (bool): Take a full page screenshot.
+      full_page (bool): Take a full page screenshot. Ignored when ``locator``
+        is set (the locator's bounding box wins).
       context: A method to build the Playwright context.
       headers (dict): Custom request header.
       device_scale_factor (int): The device scale factor for the screenshot.
@@ -194,6 +205,11 @@ class ScreenshotDirective(SphinxDirective, Figure):
         Format: comma-separated list of codes (e.g., "200,201,302").
         Defaults to "200,302" (OK and redirect).
       location (str, optional): Document location for warning messages.
+      locator (str, optional): Playwright selector. When set, the screenshot
+        is cropped to the bounding box of the matched element rather than
+        capturing the viewport. The selector must match a single element
+        (Playwright strict mode). PDF generation, when enabled, remains
+        page-level since Playwright's PDF API has no per-element variant.
     """
     if expected_status_codes is None:
       expected_status_codes = "200,302"
@@ -247,7 +263,10 @@ class ScreenshotDirective(SphinxDirective, Figure):
       except PlaywrightTimeoutError:
         raise RuntimeError('Timeout error occured at %s in executing\n%s' %
                            (url, interactions))
-      page.screenshot(path=filepath, full_page=full_page)
+      if locator:
+        page.locator(locator).screenshot(path=filepath)
+      else:
+        page.screenshot(path=filepath, full_page=full_page)
       if generate_pdf:
         page.emulate_media(media='screen')
         root, ext = os.path.splitext(filepath)
@@ -350,6 +369,7 @@ class ScreenshotDirective(SphinxDirective, Figure):
     status_code = self.options.get('status-code', None)
     timeout = self.options.get('timeout',
                                self.env.config.screenshot_default_timeout)
+    locator = self.options.get('locator', '')
     request_headers = {**self.env.config.screenshot_default_headers}
     if headers:
       for header in headers.strip().split("\n"):
@@ -358,12 +378,17 @@ class ScreenshotDirective(SphinxDirective, Figure):
 
     # Generate filename based on hash of parameters
     hash_input = "_".join([
-        raw_path, browser,
+        raw_path,
+        browser,
         str(viewport_height),
-        str(viewport_width), color_scheme, context, interactions,
+        str(viewport_width),
+        color_scheme,
+        context,
+        interactions,
         str(full_page),
         str(device_scale_factor),
-        str(status_code or "")
+        str(status_code or ""),
+        locator,
     ])
     filename = hashlib.md5(hash_input.encode()).hexdigest() + '.png'
     filepath = os.path.join(ss_dirpath, filename)
@@ -376,14 +401,13 @@ class ScreenshotDirective(SphinxDirective, Figure):
 
     # Check if the file already exists. If not, take a screenshot
     if not os.path.exists(filepath):
-      fut = self.pool.submit(ScreenshotDirective.take_screenshot,
-                             url_or_filepath, browser, viewport_width,
-                             viewport_height, filepath, screenshot_init_script,
-                             interactions, pdf,
-                             typing.cast(ColorScheme, color_scheme), full_page,
-                             context_builder, request_headers,
-                             device_scale_factor, locale, timezone,
-                             status_code, self.env.docname, timeout)
+      fut = self.pool.submit(
+          ScreenshotDirective.take_screenshot, url_or_filepath, browser,
+          viewport_width, viewport_height, filepath,
+          screenshot_init_script, interactions, pdf,
+          typing.cast(ColorScheme, color_scheme), full_page, context_builder,
+          request_headers, device_scale_factor, locale, timezone, status_code,
+          self.env.docname, timeout, locator or None)
       fut.result()
 
     rel_ss_dirpath = os.path.relpath(ss_dirpath, start=docdir)

--- a/tests/roots/test-locator/conf.py
+++ b/tests/roots/test-locator/conf.py
@@ -1,0 +1,20 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).parent.resolve()))
+
+extensions = ['sphinxcontrib.screenshot']
+screenshot_apps = {"example": "example_locator_app:create_app"}

--- a/tests/roots/test-locator/example_locator_app.py
+++ b/tests/roots/test-locator/example_locator_app.py
@@ -1,0 +1,27 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import pathlib
+
+
+def create_app(sphinx_app):
+
+  def hello_world_app(environ, start_response):
+    headers = [('Content-type', 'text/html; charset=utf-8')]
+    start_response('200 OK', headers)
+
+    path = pathlib.Path(__file__).parent.resolve() / "index.html"
+    with open(path, "rb") as fd:
+      return [fd.read()]
+
+  return hello_world_app

--- a/tests/roots/test-locator/index.html
+++ b/tests/roots/test-locator/index.html
@@ -1,0 +1,30 @@
+<html>
+    <head>
+        <style>
+        body {
+            font-family: arial;
+            font-size: 10px;
+            margin: 0;
+            padding: 0;
+        }
+        .box {
+            width: 200px;
+            height: 100px;
+            margin: 20px;
+            color: #FFFFFF;
+        }
+        #foo {
+            background: #ff0000;
+        }
+        #bar {
+            background: #0000ff;
+            width: 400px;
+            height: 50px;
+        }
+        </style>
+    </head>
+    <body>
+        <div id="foo" class="box">foo</div>
+        <div id="bar" class="box">bar</div>
+    </body>
+</html>

--- a/tests/roots/test-locator/index.rst
+++ b/tests/roots/test-locator/index.rst
@@ -1,0 +1,2 @@
+.. screenshot:: |example|
+   :locator: #foo

--- a/tests/test_locator.py
+++ b/tests/test_locator.py
@@ -1,0 +1,47 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from io import StringIO
+
+import pytest
+from bs4 import BeautifulSoup
+from PIL import Image
+from sphinx.testing.util import SphinxTestApp
+
+
+@pytest.mark.sphinx('html', testroot="locator")
+def test_locator_option(app: SphinxTestApp, status: StringIO,
+                        warning: StringIO) -> None:
+  """A :locator: directive crops the screenshot to the matched element.
+
+  The fixture page contains two boxes:
+    - ``#foo`` (200x100, the locator target)
+    - ``#bar`` (400x50)
+
+  The captured image must match ``#foo``'s bounding box (200x100 at
+  the configured device scale factor of 1), distinct from the default
+  viewport size that would otherwise apply.
+  """
+  app.build()
+  out_html = app.outdir / "index.html"
+
+  soup = BeautifulSoup(out_html.read_text(), "html.parser")
+  imgs = soup.find_all('img')
+  assert imgs, "expected a screenshot image"
+
+  img_path = app.outdir / imgs[0]['src']
+  with Image.open(img_path) as img:
+    width, height = img.size
+
+  assert (width, height) == (200, 100), (
+      f"expected #foo's bounding box (200x100), got {width}x{height}")


### PR DESCRIPTION
This allow to use a CSS selector to crop the screenshot around a single element.