### PR TITLE
Simplify exception handling in _resolve_url

### DIFF
--- a/sphinxcontrib/screenshot/_common.py
+++ b/sphinxcontrib/screenshot/_common.py
@@ -286,19 +286,19 @@ class _PlaywrightDirective(SphinxDirective):
         # Resolve symlinks and .. segments for robust containment check.
         abs_target = Path(target_path).resolve()
         abs_srcdir = Path(self.env.srcdir).resolve()
-
-        if not abs_target.is_relative_to(abs_srcdir):
-          raise RuntimeError(
-              f'Security Error: Access to {url_or_filepath} is restricted '
-              f'to the Sphinx source directory ({abs_srcdir}).')
-
-        return abs_target.as_uri()
-      except (ValueError, RuntimeError, OSError) as e:
-        if isinstance(e, RuntimeError) and 'Security Error' in str(e):
-          raise
+      except (ValueError, RuntimeError, OSError):
+        # If resolution fails, treat it as a security violation to be safe.
         raise RuntimeError(
             f'Security Error: Access to {url_or_filepath} is restricted '
             f'to the Sphinx source directory ({self.env.srcdir}).')
+
+      # Verify the resolved path is within the Sphinx source directory.
+      if not abs_target.is_relative_to(abs_srcdir):
+        raise RuntimeError(
+            f'Security Error: Access to {url_or_filepath} is restricted '
+            f'to the Sphinx source directory ({abs_srcdir}).')
+
+      return abs_target.as_uri()
 
     raise RuntimeError(f'Invalid URL: {url_or_filepath}')
 


### PR DESCRIPTION
I've refactored the `_resolve_url` method in `sphinxcontrib/screenshot/_common.py` to address the redundant `RuntimeError` passing.

Specifically, I:
1. Narrowed the `try...except` block to only cover the `Path.resolve()` operations.
2. Moved the security containment check (`is_relative_to`) outside of that `try` block.
3. Removed the redundant `if isinstance(e, RuntimeError) and 'Security Error' in str(e): raise` check.

This simplification maintains the same security guarantees and error messages while making the code more idiomatic and readable. I've verified the change by running the existing test suite, particularly `tests/test_security.py`, and all tests passed.

---
*PR created automatically by Jules for task [5127441686453379089](https://jules.google.com/task/5127441686453379089) started by @tushuhei*