### PR TITLE
🛡️ Sentinel: Harden error messages to prevent information disclosure

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -4,3 +4,10 @@
 **Learning:** Path resolution logic that converts relative paths to absolute URLs (like `file://`) must explicitly verify that the final path is within an allowed boundary (e.g., the project root). Simply normalizing the path is not enough, as traversal sequences can still escape the intended directory. Also, `urlparse` might not handle platform-specific path conventions for `file://` URLs as well as `urllib.request.url2pathname`.
 
 **Prevention:** Always use `os.path.commonpath` or `Path.relative_to` to verify that a resolved file path is contained within the expected base directory. Integrate these checks at the end of the resolution process to ensure all potential bypasses (relative paths, absolute paths, URLs) are covered.
+
+## 2026-05-08 - Information Disclosure in Error Messages
+**Vulnerability:** Error messages (RuntimeError) raised during path resolution and Playwright operations were leaking sensitive information, including the absolute path of the Sphinx source directory, internal function names, and raw JavaScript `interactions` scripts which could contain credentials or session tokens.
+
+**Learning:** Exception messages that bubble up to build logs or user-facing reports should be sanitized. While descriptive errors are helpful for debugging, they should not include server-side filesystem paths or raw input that might contain secrets.
+
+**Prevention:** Use generic error messages for security-related failures. Instead of including the problematic value or the absolute path in the error string, provide a clear explanation of the policy violation. Ensure that user-provided scripts or data are never echoed back in exceptions if they could contain sensitive information.

--- a/sphinxcontrib/screenshot/_common.py
+++ b/sphinxcontrib/screenshot/_common.py
@@ -156,9 +156,10 @@ def _prepare_context(
       context = _invoke_context_builder(context_builder, browser, url,
                                         color_scheme, record_video_dir)
     except PlaywrightTimeoutError:
+      # Do not leak the internal function name in the error message.
       raise RuntimeError(
-          'Timeout error occurred at %s in executing py init script %s' %
-          (url, context_builder.__name__))
+          f'Timeout error occurred at {url} in executing the custom context '
+          'builder.')
   else:
     new_context_kwargs: typing.Dict[str, typing.Any] = dict(
         color_scheme=color_scheme,
@@ -288,15 +289,17 @@ class _PlaywrightDirective(SphinxDirective):
         abs_srcdir = Path(self.env.srcdir).resolve()
       except (ValueError, RuntimeError, OSError):
         # If resolution fails, treat it as a security violation to be safe.
+        # Do not leak the absolute path in the error message.
         raise RuntimeError(
             f'Security Error: Access to {url_or_filepath} is restricted '
-            f'to the Sphinx source directory ({self.env.srcdir}).')
+            'to the Sphinx source directory.')
 
       # Verify the resolved path is within the Sphinx source directory.
       if not abs_target.is_relative_to(abs_srcdir):
+        # Do not leak the absolute path in the error message.
         raise RuntimeError(
             f'Security Error: Access to {url_or_filepath} is restricted '
-            f'to the Sphinx source directory ({abs_srcdir}).')
+            'to the Sphinx source directory.')
 
       return abs_target.as_uri()
 

--- a/sphinxcontrib/screenshot/_screencast.py
+++ b/sphinxcontrib/screenshot/_screencast.py
@@ -248,8 +248,11 @@ class ScreencastDirective(_PlaywrightDirective, Figure):
 
             crop_box = (x, y, w, h)
         except PlaywrightTimeoutError as e:
-          raise RuntimeError('Timeout error occurred at %s in executing\n%s' %
-                             (url, interactions)) from e
+          # Do not leak the interactions string in the error message as it
+          # may contain sensitive data (e.g. passwords or tokens).
+          raise RuntimeError(
+              f'Timeout error occurred at {url} during page interactions.'
+          ) from e
 
         # Keep a reference to the video before closing — page.close() and
         # context.close() are required to flush the .webm to disk before

--- a/sphinxcontrib/screenshot/_screenshot.py
+++ b/sphinxcontrib/screenshot/_screenshot.py
@@ -199,8 +199,10 @@ class ScreenshotDirective(_PlaywrightDirective, Figure):
         _navigate(page, url, valid_codes, expected_status_codes, location)
         _run_interactions(page, interactions)
       except PlaywrightTimeoutError:
-        raise RuntimeError('Timeout error occurred at %s in executing\n%s' %
-                           (url, interactions))
+        # Do not leak the interactions string in the error message as it
+        # may contain sensitive data (e.g. passwords or tokens).
+        raise RuntimeError(
+            f'Timeout error occurred at {url} during page interactions.')
       if locator:
         if any(locator_padding):
           # Compute the bbox manually so we can widen it by locator_padding

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -48,17 +48,23 @@ def test_resolve_url_security():
 
     # 4. Test path traversal attempt (relative)
     # We use a path that is guaranteed to be outside the tmp_dir
-    with pytest.raises(RuntimeError, match='Security Error'):
+    with pytest.raises(RuntimeError, match='Security Error') as excinfo:
       directive._resolve_url('../../etc/passwd')
+    # Verify that absolute path is NOT leaked in the error message
+    assert str(srcdir) not in str(excinfo.value)
 
     # 5. Test path traversal attempt (absolute file://)
     # On Windows, /etc/passwd doesn't exist, but we just want to see it blocked
-    with pytest.raises(RuntimeError, match='Security Error'):
+    with pytest.raises(RuntimeError, match='Security Error') as excinfo:
       directive._resolve_url('file:///etc/passwd')
+    # Verify that absolute path is NOT leaked in the error message
+    assert str(srcdir) not in str(excinfo.value)
 
     # 6. Test absolute path outside srcdir
-    with pytest.raises(RuntimeError, match='Security Error'):
+    with pytest.raises(RuntimeError, match='Security Error') as excinfo:
       directive._resolve_url('/../etc/passwd')
+    # Verify that absolute path is NOT leaked in the error message
+    assert str(srcdir) not in str(excinfo.value)
 
     # 7. Test http/https are still allowed
     assert directive._resolve_url('http://example.com') == 'http://example.com'


### PR DESCRIPTION
🛡️ Sentinel: Harden error messages to prevent information disclosure

This PR addresses several instances of information leakage in exception messages:

🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Information Disclosure
🎯 **Impact:** 
- Leaking absolute filesystem paths can help an attacker map the server's directory structure.
- Leaking internal function names exposes implementation details.
- Leaking raw JavaScript `interactions` scripts is a HIGH risk if those scripts contain sensitive data like session tokens, passwords, or PII.
🔧 **Fix:** 
- Sanitized `RuntimeError` messages in `_common.py`, `_screenshot.py`, and `_screencast.py` to use generic descriptions instead of leaking variables.
- Added comments explaining the security concern at each site.
✅ **Verification:** 
- Updated `tests/test_security.py` to ensure absolute paths are NOT present in the error output.
- All 38 tests in the suite passed.
- Manually verified that `interactions` are no longer echoed in `RuntimeError` on timeout.

---
*PR created automatically by Jules for task [2166119503983246522](https://jules.google.com/task/2166119503983246522) started by @tushuhei*