### PR TITLE
🛡️ Sentinel: Fix information leakage in security error messages

### DIFF
--- a/sphinxcontrib/screenshot/_common.py
+++ b/sphinxcontrib/screenshot/_common.py
@@ -288,15 +288,17 @@ class _PlaywrightDirective(SphinxDirective):
         abs_srcdir = Path(self.env.srcdir).resolve()
       except (ValueError, RuntimeError, OSError):
         # If resolution fails, treat it as a security violation to be safe.
+        # Do not include the absolute path in the error message for security.
         raise RuntimeError(
             f'Security Error: Access to {url_or_filepath} is restricted '
-            f'to the Sphinx source directory ({self.env.srcdir}).')
+            'to the Sphinx source directory.')
 
       # Verify the resolved path is within the Sphinx source directory.
       if not abs_target.is_relative_to(abs_srcdir):
+        # Do not include the absolute path in the error message for security.
         raise RuntimeError(
             f'Security Error: Access to {url_or_filepath} is restricted '
-            f'to the Sphinx source directory ({abs_srcdir}).')
+            'to the Sphinx source directory.')
 
       return abs_target.as_uri()
 

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -48,17 +48,21 @@ def test_resolve_url_security():
 
     # 4. Test path traversal attempt (relative)
     # We use a path that is guaranteed to be outside the tmp_dir
-    with pytest.raises(RuntimeError, match='Security Error'):
+    with pytest.raises(RuntimeError, match='Security Error') as excinfo:
       directive._resolve_url('../../etc/passwd')
+    # Verify that the absolute source path is not leaked in the error message.
+    assert str(srcdir) not in str(excinfo.value)
 
     # 5. Test path traversal attempt (absolute file://)
     # On Windows, /etc/passwd doesn't exist, but we just want to see it blocked
-    with pytest.raises(RuntimeError, match='Security Error'):
+    with pytest.raises(RuntimeError, match='Security Error') as excinfo:
       directive._resolve_url('file:///etc/passwd')
+    assert str(srcdir) not in str(excinfo.value)
 
     # 6. Test absolute path outside srcdir
-    with pytest.raises(RuntimeError, match='Security Error'):
+    with pytest.raises(RuntimeError, match='Security Error') as excinfo:
       directive._resolve_url('/../etc/passwd')
+    assert str(srcdir) not in str(excinfo.value)
 
     # 7. Test http/https are still allowed
     assert directive._resolve_url('http://example.com') == 'http://example.com'


### PR DESCRIPTION
### 🛡️ Sentinel: [MEDIUM] Fix information leakage in security error messages

🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The `_resolve_url` method was disclosing the absolute server path of the Sphinx source directory in `RuntimeError` messages when a path traversal attempt was blocked.
🎯 **Impact:** Exposing internal directory structures can provide an attacker with valuable information about the server's filesystem, aiding in further exploitation of other potential vulnerabilities.
🔧 **Fix:** Sanitized the error messages by removing the absolute paths and replacing them with a generic description ("the Sphinx source directory"). Added comments explaining the security concern.
✅ **Verification:**
1. Ran a reproduction script verifying that the absolute path is no longer present in the error message when attempting to access restricted files (e.g., `file:///etc/passwd`).
2. Updated `tests/test_security.py` with explicit assertions to ensure absolute paths are not leaked.
3. All existing tests passed successfully.

---
*PR created automatically by Jules for task [15287970797481204565](https://jules.google.com/task/15287970797481204565) started by @tushuhei*