### PR TITLE
🛡️ Sentinel: Mask absolute local paths in error messages

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,3 +1,10 @@
+## 2026-05-22 - Absolute Path Leakage via file:// URLs in Exceptions
+**Vulnerability:** Resolved `file://` URLs containing absolute paths were being included in `RuntimeError` messages and log warnings when operations like navigation or element location failed. This disclosed the build server's internal directory structure.
+
+**Learning:** Normalizing or resolving paths to absolute URLs is necessary for internal logic but these URLs must be sanitized before being included in any output that might reach a user or a persistent log.
+
+**Prevention:** Use a dedicated sanitization helper like `_mask_url` to redact sensitive schemes (like `file://`) from URLs before they are interpolated into exception messages or log entries.
+
 ## 2026-05-21 - Path Traversal Vulnerability in file:// URL handling
 **Vulnerability:** The `_resolve_url` method in `_common.py` did not validate that resolved `file://` URLs or relative paths pointing to local files were contained within the Sphinx source directory. This allowed a malicious or misconfigured Sphinx project to take screenshots of sensitive local files (e.g., `/etc/passwd`) by providing absolute `file://` URLs or using `../` traversal in relative paths.
 

--- a/sphinxcontrib/screenshot/_common.py
+++ b/sphinxcontrib/screenshot/_common.py
@@ -117,6 +117,13 @@ def _hash_filename(parts: typing.Iterable[typing.Any], extension: str) -> str:
   return hashlib.md5(payload.encode()).hexdigest() + extension
 
 
+def _mask_url(url: str) -> str:
+  """Mask local file URLs to avoid leaking absolute paths in error messages."""
+  if url.lower().startswith('file://'):
+    return '<local file>'
+  return url
+
+
 def _invoke_context_builder(
     context_builder: typing.Callable, browser: Browser, url: str,
     color_scheme: ColorScheme,
@@ -158,8 +165,8 @@ def _prepare_context(
     except PlaywrightTimeoutError:
       # Do not leak the internal function name in the error message.
       raise RuntimeError(
-          f'Timeout error occurred at {url} in executing the custom context '
-          'builder.')
+          f'Timeout error occurred at {_mask_url(url)} in executing the '
+          'custom context builder.')
   else:
     new_context_kwargs: typing.Dict[str, typing.Any] = dict(
         color_scheme=color_scheme,
@@ -195,7 +202,7 @@ def _navigate(page, url: str, valid_codes: typing.List[int],
 
   if response and response.status not in valid_codes:
     logger.warning(
-        f'Page {url} returned status code {response.status}, '
+        f'Page {_mask_url(url)} returned status code {response.status}, '
         f'expected one of: {expected_status_codes}',
         type='screenshot',
         subtype='status_code',

--- a/sphinxcontrib/screenshot/_screencast.py
+++ b/sphinxcontrib/screenshot/_screencast.py
@@ -28,7 +28,7 @@ from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 from playwright.sync_api import sync_playwright
 from sphinx.util import logging as sphinx_logging
 
-from ._common import (ContextBuilder, _hash_filename, _navigate,
+from ._common import (ContextBuilder, _hash_filename, _mask_url, _navigate,
                       _PlaywrightDirective, _prepare_context,
                       _run_interactions, parse_expected_status_codes,
                       parse_locator_padding)
@@ -225,7 +225,7 @@ class ScreencastDirective(_PlaywrightDirective, Figure):
             if bbox is None:
               raise RuntimeError(
                   f'Locator {locator!r} did not match a visible element on '
-                  f'{url}.')
+                  f'{_mask_url(url)}.')
 
             # Floor x/y and ceil w/h so the bounding box always encloses the
             # element (the opposite would shave off sub-pixel edges). Clamp
@@ -251,8 +251,8 @@ class ScreencastDirective(_PlaywrightDirective, Figure):
           # Do not leak the interactions string in the error message as it
           # may contain sensitive data (e.g. passwords or tokens).
           raise RuntimeError(
-              f'Timeout error occurred at {url} during page interactions.'
-          ) from e
+              f'Timeout error occurred at {_mask_url(url)} during page '
+              'interactions.') from e
 
         # Keep a reference to the video before closing — page.close() and
         # context.close() are required to flush the .webm to disk before

--- a/sphinxcontrib/screenshot/_screenshot.py
+++ b/sphinxcontrib/screenshot/_screenshot.py
@@ -23,7 +23,7 @@ from playwright._impl._helper import ColorScheme
 from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 from playwright.sync_api import sync_playwright
 
-from ._common import (ContextBuilder, _hash_filename, _navigate,
+from ._common import (ContextBuilder, _hash_filename, _mask_url, _navigate,
                       _PlaywrightDirective, _prepare_context,
                       _run_interactions, parse_expected_status_codes,
                       parse_locator_padding)
@@ -202,7 +202,8 @@ class ScreenshotDirective(_PlaywrightDirective, Figure):
         # Do not leak the interactions string in the error message as it
         # may contain sensitive data (e.g. passwords or tokens).
         raise RuntimeError(
-            f'Timeout error occurred at {url} during page interactions.')
+            f'Timeout error occurred at {_mask_url(url)} during page '
+            'interactions.')
       if locator:
         if any(locator_padding):
           # Compute the bbox manually so we can widen it by locator_padding
@@ -219,7 +220,7 @@ class ScreenshotDirective(_PlaywrightDirective, Figure):
           if bbox is None:
             raise RuntimeError(
                 f'Locator {locator!r} did not match a visible element on '
-                f'{url}.')
+                f'{_mask_url(url)}.')
           x = max(0, math.floor(bbox['x']) - pad_left)
           y = max(0, math.floor(bbox['y']) - pad_top)
           w = min(


### PR DESCRIPTION
Identified that `file://` URLs containing absolute paths were being leaked in `RuntimeError` messages and log warnings during screenshot and screencast operations. This could disclose sensitive information about the build environment's filesystem structure.

I've introduced a `_mask_url` utility in `_common.py` that replaces `file://` URLs with a generic `<local file>` placeholder. I've updated all relevant error-handling and logging locations in `_common.py`, `_screenshot.py`, and `_screencast.py` to use this utility.

Verification:
- Added and ran reproduction scripts to confirm that absolute paths are no longer disclosed in `RuntimeError` and `logger.warning` messages.
- Ran existing security tests (`tests/test_security.py`) to ensure no regressions in path traversal protections.
- Verified compliance with project style guides using `pre-commit`.

---
*PR created automatically by Jules for task [926505575422110625](https://jules.google.com/task/926505575422110625) started by @tushuhei*