### PR TITLE
Bump version to 2.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sphinxcontrib-screenshot"
-version = "1.2.1"
+version = "2.0.0"
 description = "A Sphinx extension to embed webpage screenshots."
 readme = "README.md"
 license = { text = "Apache-2.0" }


### PR DESCRIPTION
This PR bumps the version of `sphinxcontrib-screenshot` from 1.2.1 to 2.0.0.

Key changes:
- Updated `version` in `pyproject.toml`.
- Verified that `sphinxcontrib/screenshot/__init__.py` and `doc/conf.py` correctly retrieve the version from metadata.
- Ran all unit tests and pre-commit hooks to ensure stability.

---
*PR created automatically by Jules for task [13995072447241865746](https://jules.google.com/task/13995072447241865746) started by @tushuhei*