### PR TITLE
🛡️ Sentinel: Mask file:// URLs in logs and error messages

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -11,3 +11,10 @@
 **Learning:** Exception messages that bubble up to build logs or user-facing reports should be sanitized. While descriptive errors are helpful for debugging, they should not include server-side filesystem paths or raw input that might contain secrets.
 
 **Prevention:** Use generic error messages for security-related failures. Instead of including the problematic value or the absolute path in the error string, provide a clear explanation of the policy violation. Ensure that user-provided scripts or data are never echoed back in exceptions if they could contain sensitive information.
+
+## 2026-06-15 - Environmental Confidentiality via URL Masking
+**Vulnerability:** Even when error messages were somewhat sanitized, some logs and exceptions still interpolated the full `file://` URL, which contains the absolute filesystem path of the documentation source directory.
+
+**Learning:** Manually sanitizing every error message is error-prone. A centralized utility for masking sensitive components of a URL (like local file paths) ensures consistency across the codebase.
+
+**Prevention:** Use a `_mask_url` helper to replace `file://` URLs with a generic `<local file>` placeholder before including them in any user-facing error messages or building logs. This preserves debugging context (knowing a local file was involved) without revealing the underlying host's directory structure.

--- a/sphinxcontrib/screenshot/_common.py
+++ b/sphinxcontrib/screenshot/_common.py
@@ -101,6 +101,13 @@ def resolve_python_method(import_path: str):
   return method
 
 
+def _mask_url(url: str) -> str:
+  """Mask local file URLs to avoid leaking absolute paths in logs/errors."""
+  if url.lower().startswith('file://'):
+    return '<local file>'
+  return url
+
+
 def _hash_filename(parts: typing.Iterable[typing.Any], extension: str) -> str:
   """Build a deterministic ``<md5><extension>`` filename from arbitrary parts.
 
@@ -158,8 +165,8 @@ def _prepare_context(
     except PlaywrightTimeoutError:
       # Do not leak the internal function name in the error message.
       raise RuntimeError(
-          f'Timeout error occurred at {url} in executing the custom context '
-          'builder.')
+          f'Timeout error occurred at {_mask_url(url)} in executing the '
+          'custom context builder.')
   else:
     new_context_kwargs: typing.Dict[str, typing.Any] = dict(
         color_scheme=color_scheme,
@@ -195,7 +202,7 @@ def _navigate(page, url: str, valid_codes: typing.List[int],
 
   if response and response.status not in valid_codes:
     logger.warning(
-        f'Page {url} returned status code {response.status}, '
+        f'Page {_mask_url(url)} returned status code {response.status}, '
         f'expected one of: {expected_status_codes}',
         type='screenshot',
         subtype='status_code',

--- a/sphinxcontrib/screenshot/_screencast.py
+++ b/sphinxcontrib/screenshot/_screencast.py
@@ -28,7 +28,7 @@ from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 from playwright.sync_api import sync_playwright
 from sphinx.util import logging as sphinx_logging
 
-from ._common import (ContextBuilder, _hash_filename, _navigate,
+from ._common import (ContextBuilder, _hash_filename, _mask_url, _navigate,
                       _PlaywrightDirective, _prepare_context,
                       _run_interactions, parse_expected_status_codes,
                       parse_locator_padding)
@@ -225,7 +225,7 @@ class ScreencastDirective(_PlaywrightDirective, Figure):
             if bbox is None:
               raise RuntimeError(
                   f'Locator {locator!r} did not match a visible element on '
-                  f'{url}.')
+                  f'{_mask_url(url)}.')
 
             # Floor x/y and ceil w/h so the bounding box always encloses the
             # element (the opposite would shave off sub-pixel edges). Clamp
@@ -251,7 +251,8 @@ class ScreencastDirective(_PlaywrightDirective, Figure):
           # Do not leak the interactions string in the error message as it
           # may contain sensitive data (e.g. passwords or tokens).
           raise RuntimeError(
-              f'Timeout error occurred at {url} during page interactions.'
+              f'Timeout error occurred at {_mask_url(url)} during page '
+              'interactions.'
           ) from e
 
         # Keep a reference to the video before closing — page.close() and

--- a/sphinxcontrib/screenshot/_screencast.py
+++ b/sphinxcontrib/screenshot/_screencast.py
@@ -252,8 +252,7 @@ class ScreencastDirective(_PlaywrightDirective, Figure):
           # may contain sensitive data (e.g. passwords or tokens).
           raise RuntimeError(
               f'Timeout error occurred at {_mask_url(url)} during page '
-              'interactions.'
-          ) from e
+              'interactions.') from e
 
         # Keep a reference to the video before closing — page.close() and
         # context.close() are required to flush the .webm to disk before

--- a/sphinxcontrib/screenshot/_screenshot.py
+++ b/sphinxcontrib/screenshot/_screenshot.py
@@ -23,7 +23,7 @@ from playwright._impl._helper import ColorScheme
 from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 from playwright.sync_api import sync_playwright
 
-from ._common import (ContextBuilder, _hash_filename, _navigate,
+from ._common import (ContextBuilder, _hash_filename, _mask_url, _navigate,
                       _PlaywrightDirective, _prepare_context,
                       _run_interactions, parse_expected_status_codes,
                       parse_locator_padding)
@@ -202,7 +202,8 @@ class ScreenshotDirective(_PlaywrightDirective, Figure):
         # Do not leak the interactions string in the error message as it
         # may contain sensitive data (e.g. passwords or tokens).
         raise RuntimeError(
-            f'Timeout error occurred at {url} during page interactions.')
+            f'Timeout error occurred at {_mask_url(url)} during page '
+            'interactions.')
       if locator:
         if any(locator_padding):
           # Compute the bbox manually so we can widen it by locator_padding
@@ -219,7 +220,7 @@ class ScreenshotDirective(_PlaywrightDirective, Figure):
           if bbox is None:
             raise RuntimeError(
                 f'Locator {locator!r} did not match a visible element on '
-                f'{url}.')
+                f'{_mask_url(url)}.')
           x = max(0, math.floor(bbox['x']) - pad_left)
           y = max(0, math.floor(bbox['y']) - pad_top)
           w = min(

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -72,9 +72,23 @@ def test_resolve_url_security():
     assert res == 'https://example.com'
 
 
+def test_mask_url():
+  from sphinxcontrib.screenshot._common import _mask_url
+
+  # Test file:// URL is masked
+  assert _mask_url('file:///etc/passwd') == '<local file>'
+  assert _mask_url('FILE:///etc/passwd') == '<local file>'
+
+  # Test http/https URLs are NOT masked
+  assert _mask_url('http://example.com') == 'http://example.com'
+  assert _mask_url('https://example.com') == 'https://example.com'
+
+
 # CLEANUP: Remove the PropertyMock from the class to avoid side effects
 @pytest.fixture(autouse=True)
 def cleanup_mock():
   yield
-  if hasattr(_PlaywrightDirective, 'env'):
+  try:
     del _PlaywrightDirective.env
+  except AttributeError:
+    pass


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Absolute filesystem paths were leaked in error messages and logs when using `file://` URLs.
🎯 Impact: Disclosure of server-side directory structure to users viewing build logs or error reports.
🔧 Fix: Introduced a `_mask_url` utility in `_common.py` that replaces `file://` URLs with a generic `<local file>` placeholder. Applied this utility to all relevant error and warning messages.
✅ Verification: Added a new test `test_mask_url` in `tests/test_security.py` and verified all tests pass.

---
*PR created automatically by Jules for task [3998926559483571275](https://jules.google.com/task/3998926559483571275) started by @tushuhei*