### PR TITLE
Add `:alias:` option for stable artifact filenames

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -59,6 +59,34 @@ and supports all its options (`:align:`, `:alt:`, `:figclass:`, `:figwidth:`, `:
 
         An example of screenshot using the figure `:align:` and `:width:` options.
 
+.. _alias:
+
+``:alias:``
+===========
+
+Artifacts are named after a hash of all their generation parameters, so the
+filenames change whenever an option changes and are not predictable. Set
+``:alias:`` to also write the artifact under a stable, predictable name. This
+is convenient to link to the file from outside the documentation (an external
+page, a README…).
+
+.. code-block:: rst
+
+    .. screenshot:: http://www.example.com
+      :alias: homepage
+
+The hashed file is still produced (it stays the build cache); ``:alias:`` adds
+a copy next to it. The example above is then available at
+``_static/screenshots/homepage.png`` (and ``homepage.pdf`` when :ref:`pdf
+<pdf>` is set). The same option works on :rst:dir:`screencast`, producing
+``_static/screencasts/homepage.webm`` (plus ``homepage.png`` for an automatic
+poster). With :ref:`color-scheme: auto <color-scheme>`, two artifacts are
+written, suffixed ``-light`` and ``-dark`` (e.g. ``homepage-light.png``).
+
+The alias is a bare filename stem, restricted to ASCII letters, digits,
+``.``, ``_`` and ``-``. If two directives share the same alias, the last one
+written wins.
+
 .. _browser:
 
 ``:browser:``

--- a/sphinxcontrib/screenshot/_common.py
+++ b/sphinxcontrib/screenshot/_common.py
@@ -17,6 +17,7 @@ import hashlib
 import importlib
 import json
 import os
+import shutil
 import typing
 import urllib.request
 from concurrent.futures import ThreadPoolExecutor
@@ -92,6 +93,27 @@ def parse_locator_padding(
 
   raise ValueError('locator-padding accepts 1, 2, 3, or 4 values (CSS padding '
                    f'shorthand), got {len(parts)}.')
+
+
+_ALIAS_ALLOWED = set('._-')
+
+
+def validate_alias(value: str) -> str:
+  """Validate an ``:alias:`` value: an ASCII filename stem, no path parts.
+
+  The alias becomes ``<alias>.<ext>`` next to the hashed artifact and is
+  served through a URL, so it is restricted to ASCII letters, digits, ``.``,
+  ``_`` and ``-``. That allowlist also rules out path separators (no directory
+  traversal); ``.`` and ``..`` are excluded explicitly since the dot is
+  otherwise allowed.
+  """
+  stripped = (value or '').strip()
+  if (not stripped or stripped in ('.', '..') or not stripped.isascii() or
+      not all(c.isalnum() or c in _ALIAS_ALLOWED for c in stripped)):
+    raise ValueError(
+        'alias must be a filename stem using only ASCII letters, digits, '
+        f'".", "_" or "-", got {value!r}.')
+  return stripped
 
 
 def resolve_python_method(import_path: str):
@@ -203,8 +225,28 @@ class _PlaywrightDirective(SphinxDirective):
       'device-scale-factor': directives.positive_int,
       'status-code': str,
       'timeout': directives.positive_int,
+      'alias': validate_alias,
   }
   pool = ThreadPoolExecutor()
+
+  def _write_alias(self,
+                   primary_filepath: str,
+                   alias: str,
+                   suffix: str = '') -> None:
+    """Copy every artifact sharing the hashed stem to a stable-named alias.
+
+    A single directive produces one file per output (``<hash>.png`` plus
+    ``<hash>.pdf`` for a screenshot, or ``<hash>.webm`` plus ``<hash>.png`` for
+    a screencast with an automatic poster). They all share the hash stem, so a
+    ``<stem>.*`` glob copies the media and its companions in one pass. The
+    alias coexists with the hashed files (which stay the cache key); the copy
+    is unconditional so the alias tracks the current hash when an option
+    changes. On a name clash the last write wins.
+    """
+    primary = Path(primary_filepath)
+    target_stem = alias + suffix
+    for src in primary.parent.glob(primary.stem + '.*'):
+      shutil.copyfile(src, src.parent / (target_stem + src.suffix))
 
   def _evaluate_substitutions(self, text: str) -> str:
     substitutions = self.state.document.substitution_defs
@@ -317,14 +359,14 @@ class _PlaywrightDirective(SphinxDirective):
     original_arguments = self.arguments[:]
     original_options = self.options.copy()
 
-    light_nodes = generator(color_scheme='light')
+    light_nodes = generator(color_scheme='light', alias_suffix='-light')
     light_nodes = self._add_css_class_to_nodes(light_nodes, 'only-light',
                                                inner_types)
 
     self.arguments = original_arguments[:]
     self.options = original_options.copy()
 
-    dark_nodes = generator(color_scheme='dark')
+    dark_nodes = generator(color_scheme='dark', alias_suffix='-dark')
     dark_nodes = self._add_css_class_to_nodes(dark_nodes, 'only-dark',
                                               inner_types)
 

--- a/sphinxcontrib/screenshot/_screencast.py
+++ b/sphinxcontrib/screenshot/_screencast.py
@@ -394,8 +394,8 @@ class ScreencastDirective(_PlaywrightDirective, Figure):
 
   def _generate_single_screencast(
       self,
-      color_scheme: typing.Optional[str] = None
-  ) -> typing.Sequence[nodes.Node]:
+      color_scheme: typing.Optional[str] = None,
+      alias_suffix: str = '') -> typing.Sequence[nodes.Node]:
     """Generate a single screencast and return the docutils nodes."""
     poster_mode, poster_value = self._parse_poster()
 
@@ -557,6 +557,10 @@ class ScreencastDirective(_PlaywrightDirective, Figure):
           ffmpeg_executable=ffmpeg_executable_value,
           fps=fps_value)
       fut.result()
+
+    alias = self.options.get('alias')
+    if alias:
+      self._write_alias(filepath, alias, alias_suffix)
 
     # Compute src relative to the HTML output of the current doc, since the
     # screencast node has no Sphinx-side image-collection machinery to rewrite

--- a/sphinxcontrib/screenshot/_screenshot.py
+++ b/sphinxcontrib/screenshot/_screenshot.py
@@ -255,8 +255,8 @@ class ScreenshotDirective(_PlaywrightDirective, Figure):
 
   def _generate_single_screenshot(
       self,
-      color_scheme: typing.Optional[str] = None
-  ) -> typing.Sequence[nodes.Node]:
+      color_scheme: typing.Optional[str] = None,
+      alias_suffix: str = '') -> typing.Sequence[nodes.Node]:
     """Generate a single screenshot and return the docutils nodes."""
     screenshot_init_script: str = self.env.config.screenshot_init_script or ''
     docdir = os.path.dirname(self.env.doc2path(self.env.docname))
@@ -336,6 +336,10 @@ class ScreenshotDirective(_PlaywrightDirective, Figure):
           request_headers, device_scale_factor, locale, timezone, status_code,
           self.env.docname, timeout, locator or None, locator_padding)
       fut.result()
+
+    alias = self.options.get('alias')
+    if alias:
+      self._write_alias(filepath, alias, alias_suffix)
 
     rel_ss_dirpath = os.path.relpath(ss_dirpath, start=docdir)
     rel_filepath = os.path.join(rel_ss_dirpath, filename).replace(os.sep, '/')

--- a/tests/roots/test-alias-color-scheme-auto/conf.py
+++ b/tests/roots/test-alias-color-scheme-auto/conf.py
@@ -1,0 +1,15 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+extensions = ['sphinxcontrib.screenshot']

--- a/tests/roots/test-alias-color-scheme-auto/index.rst
+++ b/tests/roots/test-alias-color-scheme-auto/index.rst
@@ -1,0 +1,3 @@
+.. screenshot:: ./page.html
+   :alias: my-shot
+   :color-scheme: auto

--- a/tests/roots/test-alias-color-scheme-auto/page.html
+++ b/tests/roots/test-alias-color-scheme-auto/page.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html>
+<head>
+<style>body { margin: 0; padding: 12px; font-family: sans-serif; }</style>
+</head>
+<body>
+<h1>Alias fixture</h1>
+</body>
+</html>

--- a/tests/roots/test-alias-screencast/anim.html
+++ b/tests/roots/test-alias-screencast/anim.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html>
+<head>
+<style>body { margin: 0; padding: 12px; font-family: sans-serif; }</style>
+</head>
+<body>
+<button id="b">Click me</button>
+<div id="counter">0</div>
+<script>
+let n = 0;
+document.getElementById('b').addEventListener('click', () => {
+  n++;
+  document.getElementById('counter').textContent = n;
+});
+</script>
+</body>
+</html>

--- a/tests/roots/test-alias-screencast/conf.py
+++ b/tests/roots/test-alias-screencast/conf.py
@@ -1,0 +1,15 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+extensions = ['sphinxcontrib.screenshot']

--- a/tests/roots/test-alias-screencast/index.rst
+++ b/tests/roots/test-alias-screencast/index.rst
@@ -1,0 +1,8 @@
+.. screencast:: ./anim.html
+   :alias: my-cast
+   :poster:
+   :viewport-width: 320
+   :viewport-height: 200
+   :interactions:
+     document.getElementById('b').click();
+     await new Promise(r => setTimeout(r, 300));

--- a/tests/roots/test-alias/conf.py
+++ b/tests/roots/test-alias/conf.py
@@ -1,0 +1,15 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+extensions = ['sphinxcontrib.screenshot']

--- a/tests/roots/test-alias/index.rst
+++ b/tests/roots/test-alias/index.rst
@@ -1,0 +1,3 @@
+.. screenshot:: ./page.html
+   :alias: my-shot
+   :pdf:

--- a/tests/roots/test-alias/page.html
+++ b/tests/roots/test-alias/page.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html>
+<head>
+<style>body { margin: 0; padding: 12px; font-family: sans-serif; }</style>
+</head>
+<body>
+<h1>Alias fixture</h1>
+</body>
+</html>

--- a/tests/test_alias.py
+++ b/tests/test_alias.py
@@ -1,0 +1,99 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from io import StringIO
+
+import pytest
+from sphinx.testing.util import SphinxTestApp
+
+from sphinxcontrib.screenshot._common import validate_alias
+
+
+@pytest.mark.parametrize('value,expected', [
+    ('my-shot', 'my-shot'),
+    ('  my-shot  ', 'my-shot'),
+    ('My_Shot.2', 'My_Shot.2'),
+    ('a', 'a'),
+])
+def test_validate_alias_accepts(value: str, expected: str) -> None:
+  assert validate_alias(value) == expected
+
+
+@pytest.mark.parametrize('value', [
+    '',
+    '   ',
+    '.',
+    '..',
+    'a/b',
+    'a\\b',
+    '../etc',
+    '/abs',
+    'a b',
+    'café',
+    'a#b',
+])
+def test_validate_alias_rejects(value: str) -> None:
+  with pytest.raises(ValueError):
+    validate_alias(value)
+
+
+@pytest.mark.sphinx('html', testroot='alias')
+def test_alias_screenshot(app: SphinxTestApp, status: StringIO,
+                          warning: StringIO) -> None:
+  """``:alias:`` copies the screenshot (and its PDF) to a stable name.
+
+  The hashed artifact stays in place; the alias is a byte-identical copy
+  alongside it, and the glob picks up the companion ``.pdf`` too.
+  """
+  app.build()
+
+  ss_dir = app.outdir / '_static' / 'screenshots'
+  alias_png = ss_dir / 'my-shot.png'
+  alias_pdf = ss_dir / 'my-shot.pdf'
+
+  assert alias_png.exists(), 'expected the aliased PNG'
+  assert alias_pdf.exists(), 'expected the aliased PDF'
+
+  hashed = [
+      p for p in ss_dir.glob('*.png') if not p.name.startswith('my-shot')
+  ]
+  assert len(hashed) == 1, 'expected exactly one hashed PNG'
+  assert alias_png.read_bytes() == hashed[0].read_bytes()
+
+
+@pytest.mark.sphinx('html', testroot='alias-color-scheme-auto')
+def test_alias_color_scheme_auto(app: SphinxTestApp, status: StringIO,
+                                 warning: StringIO) -> None:
+  """``:color-scheme: auto`` writes ``-light``/``-dark`` aliased files."""
+  app.build()
+
+  ss_dir = app.outdir / '_static' / 'screenshots'
+  assert (ss_dir / 'my-shot-light.png').exists()
+  assert (ss_dir / 'my-shot-dark.png').exists()
+  assert not (ss_dir / 'my-shot.png').exists()
+
+
+@pytest.mark.sphinx('html', testroot='alias-screencast')
+def test_alias_screencast(app: SphinxTestApp, status: StringIO,
+                          warning: StringIO) -> None:
+  """``:alias:`` copies the screencast and its automatic poster."""
+  app.build()
+
+  sc_dir = app.outdir / '_static' / 'screencasts'
+  alias_webm = sc_dir / 'my-cast.webm'
+  alias_poster = sc_dir / 'my-cast.png'
+
+  assert alias_webm.exists(), 'expected the aliased WebM'
+  assert alias_webm.stat().st_size > 0
+  assert alias_poster.exists(), 'expected the aliased poster'
+  assert alias_poster.stat().st_size > 0


### PR DESCRIPTION
I want to display images/videos generated by sphinxcontrib-screenshot in a README file to be displayed in github/gitlab. Since every artifact has an unpredictable hash as its filename base, I added a `:alias:` option that allows to have a stable filename (and thus a stable URLs) for screenshots/screencasts.

Basically it just copies the generated files under a new name.